### PR TITLE
Make buttons back to gray after pushing

### DIFF
--- a/src/app/call/call.component.html
+++ b/src/app/call/call.component.html
@@ -7,24 +7,24 @@
   </div>
     <div class="dial">
         <div class="line">
-            <button md-button disableRipple (click)="pushItem('3')">3</button>
-            <button md-button disableRipple (click)="pushItem('2')">2</button>
-            <button md-button disableRipple (click)="pushItem('1')">1</button>
+            <button md-button (click)="pushItem('3')">3</button>
+            <button md-button (click)="pushItem('2')">2</button>
+            <button md-button (click)="pushItem('1')">1</button>
         </div>
         <div class="line">
-            <button md-button disableRipple (click)="pushItem('6')">6</button>
-            <button md-button disableRipple (click)="pushItem('5')">5</button>
-            <button md-button disableRipple (click)="pushItem('4')">4</button>
+            <button md-button (click)="pushItem('6')">6</button>
+            <button md-button (click)="pushItem('5')">5</button>
+            <button md-button (click)="pushItem('4')">4</button>
         </div>
         <div class="line">
-            <button md-button disableRipple (click)="pushItem('9')">9</button>
-            <button md-button disableRipple (click)="pushItem('8')">8</button>
-            <button md-button disableRipple (click)="pushItem('7')">7</button>
+            <button md-button (click)="pushItem('9')">9</button>
+            <button md-button (click)="pushItem('8')">8</button>
+            <button md-button (click)="pushItem('7')">7</button>
         </div>
         <div class="line">
-            <button md-button disableRipple (click)="pushItem('#')">#</button>
-            <button md-button disableRipple (click)="pushItem('0')">0</button>
-            <button md-button disableRipple (click)="pushItem('*')">*</button>
+            <button md-button (click)="pushItem('#')">#</button>
+            <button md-button (click)="pushItem('0')">0</button>
+            <button md-button (click)="pushItem('*')">*</button>
         </div>
   </div>
   <div class="actions">

--- a/src/app/call/call.component.scss
+++ b/src/app/call/call.component.scss
@@ -49,6 +49,9 @@
         color: #1155CD;
         min-width: 0px !important;
     }
+    button:focus /deep/ .mat-button-focus-overlay {
+     opacity: 0;
+    }
   }
 }
 


### PR DESCRIPTION
I had to activate the ripple effect and hide the active element layer. It seems to be a bug in the angular material library.

Close #28